### PR TITLE
Enable default monitoring and 30-day retention

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ BrowserSec is a Chrome browser extension designed to enhance user security throu
 
 - **Customizable Settings**
   - OpenAI API token configuration
-  - Monitoring preferences
-  - Data retention settings
+  - Monitoring preferences (enabled by default)
+  - Data retention settings (default 30 days)
 
 - **Data Visualization**
   - Interactive dashboard

--- a/extension/options.html
+++ b/extension/options.html
@@ -17,13 +17,13 @@
     </label>
     <fieldset>
       <legend>Monitoring Preferences</legend>
-      <label><input type="checkbox" id="domTracking" /> DOM state tracking</label>
-      <label><input type="checkbox" id="screenCapture" /> Screen capture analysis</label>
-      <label><input type="checkbox" id="interactionMonitoring" /> User interaction monitoring</label>
+      <label><input type="checkbox" id="domTracking" checked /> DOM state tracking</label>
+      <label><input type="checkbox" id="screenCapture" checked /> Screen capture analysis</label>
+      <label><input type="checkbox" id="interactionMonitoring" checked /> User interaction monitoring</label>
     </fieldset>
     <label>
       Data retention (days)
-      <input type="number" id="retention" min="0" />
+      <input type="number" id="retention" min="0" value="30" />
     </label>
     <button type="submit">Save</button>
     <span id="status"></span>

--- a/extension/options.js
+++ b/extension/options.js
@@ -6,7 +6,10 @@ function saveOptions(e) {
     domTracking: document.getElementById('domTracking').checked,
     screenCapture: document.getElementById('screenCapture').checked,
     interactionMonitoring: document.getElementById('interactionMonitoring').checked,
-    retention: parseInt(document.getElementById('retention').value, 10) || 0
+    retention: (() => {
+      const val = parseInt(document.getElementById('retention').value, 10);
+      return Number.isNaN(val) ? 30 : val;
+    })()
   };
   chrome.storage.local.set(options, () => {
     const status = document.getElementById('status');
@@ -20,10 +23,10 @@ function saveOptions(e) {
 function restoreOptions() {
   chrome.storage.local.get({
     apiToken: '',
-    domTracking: false,
-    screenCapture: false,
-    interactionMonitoring: false,
-    retention: 0
+    domTracking: true,
+    screenCapture: true,
+    interactionMonitoring: true,
+    retention: 30
   }, (items) => {
     document.getElementById('apiToken').value = items.apiToken;
     document.getElementById('domTracking').checked = items.domTracking;

--- a/extension/service_worker.js
+++ b/extension/service_worker.js
@@ -2,7 +2,16 @@
 // Placeholder for continuous monitoring and intent classification
 
 chrome.runtime.onInstalled.addListener(() => {
-  console.log('BrowserSec installed');
+  chrome.storage.local.get({
+    domTracking: true,
+    screenCapture: true,
+    interactionMonitoring: true,
+    retention: 30
+  }, (items) => {
+    chrome.storage.local.set(items, () => {
+      console.log('BrowserSec installed with default settings');
+    });
+  });
 });
 
 // TODO: Implement DOM state tracking, screen capture analysis,

--- a/test/options.test.js
+++ b/test/options.test.js
@@ -62,3 +62,13 @@ test('restoreOptions populates form from chrome.storage', () => {
   assert.equal(document.getElementById('interactionMonitoring').checked, false);
   assert.equal(document.getElementById('retention').value, '10');
 });
+
+test('restoreOptions uses defaults when storage is empty', () => {
+  stored = {};
+  restoreOptions();
+
+  assert.equal(document.getElementById('domTracking').checked, true);
+  assert.equal(document.getElementById('screenCapture').checked, true);
+  assert.equal(document.getElementById('interactionMonitoring').checked, true);
+  assert.equal(document.getElementById('retention').value, '30');
+});


### PR DESCRIPTION
## Summary
- Enable DOM tracking, screen capture, and interaction monitoring by default
- Set default data retention period to 30 days
- Add service worker initialization and tests for default settings

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a0b6bd0bdc8323ab45d742e4c6c13f