### PR TITLE
style: polish settings page with new styling

### DIFF
--- a/extension/options.css
+++ b/extension/options.css
@@ -1,0 +1,66 @@
+body {
+  font-family: Arial, sans-serif;
+  background-color: #f4f4f4;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  justify-content: center;
+}
+
+.container {
+  background: #fff;
+  padding: 20px 30px;
+  margin-top: 40px;
+  border-radius: 8px;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.1);
+  width: 400px;
+}
+
+h1 {
+  font-size: 1.5em;
+  margin-bottom: 20px;
+  text-align: center;
+}
+
+label {
+  display: block;
+  margin: 15px 0 5px;
+}
+
+input[type="password"],
+input[type="number"] {
+  width: 100%;
+  padding: 8px;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  box-sizing: border-box;
+}
+
+fieldset {
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  padding: 10px;
+}
+
+legend {
+  padding: 0 5px;
+  font-weight: bold;
+}
+
+button {
+  background-color: #007bff;
+  color: #fff;
+  border: none;
+  padding: 10px 20px;
+  border-radius: 4px;
+  cursor: pointer;
+  margin-top: 15px;
+}
+
+button:hover {
+  background-color: #0056b3;
+}
+
+#status {
+  margin-left: 10px;
+}

--- a/extension/options.html
+++ b/extension/options.html
@@ -3,31 +3,30 @@
 <head>
   <meta charset="UTF-8">
   <title>BrowserSec Settings</title>
-  <style>
-    body { font-family: Arial, sans-serif; margin: 20px; }
-    label { display: block; margin-top: 10px; }
-  </style>
+  <link rel="stylesheet" href="options.css">
 </head>
 <body>
-  <h1>BrowserSec Settings</h1>
-  <form id="settings-form">
-    <label>
-      OpenAI API Token
-      <input type="password" id="apiToken" />
-    </label>
-    <fieldset>
-      <legend>Monitoring Preferences</legend>
-      <label><input type="checkbox" id="domTracking" checked /> DOM state tracking</label>
-      <label><input type="checkbox" id="screenCapture" checked /> Screen capture analysis</label>
-      <label><input type="checkbox" id="interactionMonitoring" checked /> User interaction monitoring</label>
-    </fieldset>
-    <label>
-      Data retention (days)
-      <input type="number" id="retention" min="0" value="30" />
-    </label>
-    <button type="submit">Save</button>
-    <span id="status"></span>
-  </form>
+  <div class="container">
+    <h1>BrowserSec Settings</h1>
+    <form id="settings-form">
+      <label>
+        OpenAI API Token
+        <input type="password" id="apiToken" />
+      </label>
+      <fieldset>
+        <legend>Monitoring Preferences</legend>
+        <label><input type="checkbox" id="domTracking" checked /> DOM state tracking</label>
+        <label><input type="checkbox" id="screenCapture" checked /> Screen capture analysis</label>
+        <label><input type="checkbox" id="interactionMonitoring" checked /> User interaction monitoring</label>
+      </fieldset>
+      <label>
+        Data retention (days)
+        <input type="number" id="retention" min="0" value="30" />
+      </label>
+      <button type="submit">Save</button>
+      <span id="status"></span>
+    </form>
+  </div>
   <script src="options.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add dedicated stylesheet for settings page with layout and button styling
- streamline options.html structure and link to new stylesheet

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a0b7f45f348323b8cf1dc77930e1ca