### PR TITLE
feat: send periodic screenshots to OpenAI

### DIFF
--- a/extension/content-script.js
+++ b/extension/content-script.js
@@ -3,4 +3,9 @@
 
 console.log('BrowserSec content script loaded');
 
-// TODO: Monitor DOM changes and user interactions.
+// Send a message to the background script whenever the user clicks on the page
+document.addEventListener('click', () => {
+  chrome.runtime.sendMessage({ type: 'user-click' });
+});
+
+// TODO: Monitor DOM changes and additional user interactions.

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -3,7 +3,7 @@
   "name": "BrowserSec",
   "description": "Intelligent browser security extension",
   "version": "0.1.0",
-  "permissions": ["storage", "scripting", "activeTab"],
+  "permissions": ["storage", "scripting", "activeTab", "tabs"],
   "host_permissions": ["<all_urls>"],
   "background": {
     "service_worker": "service_worker.js"

--- a/extension/options.html
+++ b/extension/options.html
@@ -20,6 +20,10 @@
         <label><input type="checkbox" id="interactionMonitoring" checked /> User interaction monitoring</label>
       </fieldset>
       <label>
+        Screenshot interval (seconds)
+        <input type="number" id="screenshotInterval" min="1" value="5" />
+      </label>
+      <label>
         Data retention (days)
         <input type="number" id="retention" min="0" value="30" />
       </label>

--- a/extension/options.js
+++ b/extension/options.js
@@ -9,6 +9,10 @@ function saveOptions(e) {
     retention: (() => {
       const val = parseInt(document.getElementById('retention').value, 10);
       return Number.isNaN(val) ? 30 : val;
+    })(),
+    screenshotInterval: (() => {
+      const val = parseInt(document.getElementById('screenshotInterval').value, 10);
+      return Number.isNaN(val) ? 5 : val;
     })()
   };
   chrome.storage.local.set(options, () => {
@@ -26,13 +30,15 @@ function restoreOptions() {
     domTracking: true,
     screenCapture: true,
     interactionMonitoring: true,
-    retention: 30
+    retention: 30,
+    screenshotInterval: 5
   }, (items) => {
     document.getElementById('apiToken').value = items.apiToken;
     document.getElementById('domTracking').checked = items.domTracking;
     document.getElementById('screenCapture').checked = items.screenCapture;
     document.getElementById('interactionMonitoring').checked = items.interactionMonitoring;
     document.getElementById('retention').value = items.retention;
+    document.getElementById('screenshotInterval').value = items.screenshotInterval;
   });
 }
 

--- a/extension/service_worker.js
+++ b/extension/service_worker.js
@@ -6,12 +6,86 @@ chrome.runtime.onInstalled.addListener(() => {
     domTracking: true,
     screenCapture: true,
     interactionMonitoring: true,
-    retention: 30
+    retention: 30,
+    screenshotInterval: 5,
+    apiToken: ''
   }, (items) => {
     chrome.storage.local.set(items, () => {
       console.log('BrowserSec installed with default settings');
     });
   });
+});
+
+let captureTimer;
+
+async function captureAndSend(apiToken) {
+  chrome.tabs.captureVisibleTab({ format: 'png' }, async (dataUrl) => {
+    if (!dataUrl) return;
+    try {
+      const response = await fetch('https://api.openai.com/v1/chat/completions', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': `Bearer ${apiToken}`
+        },
+        body: JSON.stringify({
+          model: 'gpt-4o-mini',
+          messages: [
+            {
+              role: 'user',
+              content: [
+                { type: 'text', text: 'Analyze this screenshot' },
+                { type: 'image_url', image_url: { url: dataUrl } }
+              ]
+            }
+          ]
+        })
+      });
+      const data = await response.json();
+      console.log('OpenAI response', data);
+    } catch (err) {
+      console.error('Failed to send screenshot to OpenAI', err);
+    }
+  });
+}
+
+function startScreenshotLoop() {
+  if (captureTimer) clearInterval(captureTimer);
+  chrome.storage.local.get({ apiToken: '', screenCapture: true, screenshotInterval: 5 }, (items) => {
+    if (!items.screenCapture || !items.apiToken) return;
+    captureTimer = setInterval(() => captureAndSend(items.apiToken), items.screenshotInterval * 1000);
+  });
+}
+
+startScreenshotLoop();
+
+chrome.storage.onChanged.addListener((changes, area) => {
+  if (area === 'local' && (changes.screenshotInterval || changes.apiToken || changes.screenCapture)) {
+    startScreenshotLoop();
+  }
+});
+
+function triggerOnSetting() {
+  chrome.storage.local.get({ apiToken: '', screenCapture: true }, (items) => {
+    if (!items.screenCapture || !items.apiToken) return;
+    captureAndSend(items.apiToken);
+  });
+}
+
+chrome.runtime.onMessage.addListener((msg) => {
+  if (msg.type === 'user-click') {
+    triggerOnSetting();
+  }
+});
+
+chrome.tabs.onUpdated.addListener((tabId, changeInfo) => {
+  if (changeInfo.status === 'complete') {
+    triggerOnSetting();
+  }
+});
+
+chrome.tabs.onActivated.addListener(() => {
+  triggerOnSetting();
 });
 
 // TODO: Implement DOM state tracking, screen capture analysis,

--- a/test/options.test.js
+++ b/test/options.test.js
@@ -9,6 +9,7 @@ const dom = new JSDOM(`<!DOCTYPE html><form id="settings-form">
   <input id="screenCapture" type="checkbox">
   <input id="interactionMonitoring" type="checkbox">
   <input id="retention">
+  <input id="screenshotInterval">
   <div id="status"></div>
 </form>`);
 
@@ -33,6 +34,7 @@ test('saveOptions stores settings to chrome.storage', () => {
   document.getElementById('screenCapture').checked = false;
   document.getElementById('interactionMonitoring').checked = true;
   document.getElementById('retention').value = '45';
+  document.getElementById('screenshotInterval').value = '15';
 
   saveOptions({ preventDefault() {} });
 
@@ -41,7 +43,8 @@ test('saveOptions stores settings to chrome.storage', () => {
     domTracking: true,
     screenCapture: false,
     interactionMonitoring: true,
-    retention: 45
+    retention: 45,
+    screenshotInterval: 15
   });
 });
 
@@ -51,7 +54,8 @@ test('restoreOptions populates form from chrome.storage', () => {
     domTracking: false,
     screenCapture: true,
     interactionMonitoring: false,
-    retention: 10
+    retention: 10,
+    screenshotInterval: 20
   };
 
   restoreOptions();
@@ -61,6 +65,7 @@ test('restoreOptions populates form from chrome.storage', () => {
   assert.equal(document.getElementById('screenCapture').checked, true);
   assert.equal(document.getElementById('interactionMonitoring').checked, false);
   assert.equal(document.getElementById('retention').value, '10');
+  assert.equal(document.getElementById('screenshotInterval').value, '20');
 });
 
 test('restoreOptions uses defaults when storage is empty', () => {
@@ -71,4 +76,5 @@ test('restoreOptions uses defaults when storage is empty', () => {
   assert.equal(document.getElementById('screenCapture').checked, true);
   assert.equal(document.getElementById('interactionMonitoring').checked, true);
   assert.equal(document.getElementById('retention').value, '30');
+  assert.equal(document.getElementById('screenshotInterval').value, '5');
 });


### PR DESCRIPTION
## Summary
- send a screenshot to OpenAI every 5s and whenever the user clicks or switches pages
- default screenshot interval set to 5 seconds in options and storage
- adjust options test for new default interval

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a0bfd03ec88323b21d70547aa353a2