### PR TITLE
Gracefully handle invalidated extension context in content script

### DIFF
--- a/extension/content-script.js
+++ b/extension/content-script.js
@@ -4,8 +4,22 @@
 console.log('BrowserSec content script loaded');
 
 // Send a message to the background script whenever the user clicks on the page
+// Guard against "Extension context invalidated" errors by gracefully handling
+// messaging failures (e.g. when the extension is reloaded while the content
+// script remains attached to the page).
 document.addEventListener('click', () => {
-  chrome.runtime.sendMessage({ type: 'user-click' });
+  try {
+    chrome.runtime.sendMessage({ type: 'user-click' }, () => {
+      // Accessing lastError prevents unchecked runtime errors that manifest
+      // as "Extension context invalidated" in some environments.
+      if (chrome.runtime.lastError) {
+        console.debug('BrowserSec: message failed', chrome.runtime.lastError);
+      }
+    });
+  } catch (err) {
+    // In rare cases chrome.runtime may itself be unavailable; ignore silently.
+    console.debug('BrowserSec: unable to send message', err);
+  }
 });
 
 // TODO: Monitor DOM changes and additional user interactions.


### PR DESCRIPTION
## Summary
- prevent unhandled `browser.runtime.sendMessage` rejections when the extension context disappears
- log runtime messaging errors in the content script

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a0e5aa748c8323a18c869164e44146