### PR TITLE
Capture screenshots only after user interaction

### DIFF
--- a/extension/content-script.js
+++ b/extension/content-script.js
@@ -41,4 +41,22 @@ document.addEventListener('click', () => {
   }
 });
 
+// Notify the background script whenever the user types.
+// Each key press resets a short timer in the service worker, ensuring
+// that a screenshot is captured only after typing has paused.
+document.addEventListener('keydown', () => {
+  try {
+    debugLog('debug', 'sending user-typing message');
+    chrome.runtime.sendMessage({ type: 'user-typing' }, () => {
+      if (chrome.runtime.lastError) {
+        debugLog('debug', 'message failed', chrome.runtime.lastError);
+      } else {
+        debugLog('debug', 'user-typing message sent');
+      }
+    });
+  } catch (err) {
+    debugLog('debug', 'unable to send message', err);
+  }
+});
+
 // TODO: Monitor DOM changes and additional user interactions.


### PR DESCRIPTION
## Summary
- send screenshot only when user interacts with page
- defer screenshot until 3s after typing stops

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a0fa0777688323815b3e0c3ddbfa57