### PR TITLE
Capture screenshots on navigation

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -3,7 +3,7 @@
   "name": "BrowserSec",
   "description": "Intelligent browser security extension",
   "version": "0.1.0",
-  "permissions": ["storage", "scripting", "activeTab", "tabs"],
+  "permissions": ["storage", "scripting", "activeTab", "tabs", "webNavigation"],
   "host_permissions": ["<all_urls>"],
   "background": {
     "service_worker": "service_worker.js"
@@ -20,3 +20,4 @@
     }
   ]
 }
+

--- a/extension/service_worker.js
+++ b/extension/service_worker.js
@@ -103,5 +103,26 @@ chrome.runtime.onMessage.addListener((msg) => {
   }
 });
 
+// Capture a screenshot whenever the active tab navigates to a new page
+chrome.webNavigation.onCompleted.addListener((details) => {
+  if (details.frameId !== 0) return;
+  chrome.tabs.get(details.tabId, (tab) => {
+    if (chrome.runtime.lastError || !tab.active) return;
+    debugLog('debug', 'navigation completed');
+    triggerOnSetting('navigation');
+  });
+});
+
+// Detect SPA-style navigation via the History API
+chrome.webNavigation.onHistoryStateUpdated.addListener((details) => {
+  if (details.frameId !== 0) return;
+  chrome.tabs.get(details.tabId, (tab) => {
+    if (chrome.runtime.lastError || !tab.active) return;
+    debugLog('debug', 'history state updated');
+    triggerOnSetting('history-state-updated');
+  });
+});
+
 // TODO: Implement DOM state tracking, screen capture analysis,
 // user interaction monitoring, and AI-powered intent classification.
+


### PR DESCRIPTION
## Summary
- trigger screenshot captures when tabs navigate or update history via the SPA History API
- declare `webNavigation` permission to support navigation event listeners

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a0fb3850cc8323ab3f778fe0df0fa9