### PR TITLE
Add activity dashboard and storage

### DIFF
--- a/extension/popup.html
+++ b/extension/popup.html
@@ -2,13 +2,39 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
-  <title>BrowserSec</title>
+  <title>BrowserSec Dashboard</title>
   <style>
-    body { min-width: 200px; min-height: 100px; display: flex; align-items: center; justify-content: center; font-family: Arial, sans-serif; }
+    body { font-family: Arial, sans-serif; margin: 0; padding: 10px; min-width: 400px; }
+    h1 { font-size: 18px; margin-top: 0; }
+    section { margin-bottom: 20px; }
+    table { width: 100%; border-collapse: collapse; }
+    th, td { border: 1px solid #ccc; padding: 4px; font-size: 12px; }
+    th { background-color: #f2f2f2; }
   </style>
 </head>
 <body>
-  <p>Dashboard coming soon.</p>
+  <h1>Activity Dashboard</h1>
+  <section>
+    <h2>Top Websites by Action Type</h2>
+    <table id="siteTable">
+      <thead><tr><th>Website</th><th>Action Type</th><th>Count</th></tr></thead>
+      <tbody></tbody>
+    </table>
+  </section>
+  <section>
+    <h2>Sensitive Actions</h2>
+    <table id="sensitiveTable">
+      <thead><tr><th>Action</th><th>Website</th><th>Count</th></tr></thead>
+      <tbody></tbody>
+    </table>
+  </section>
+  <section>
+    <h2>Low Prevalence Actions</h2>
+    <table id="rareTable">
+      <thead><tr><th>Action Type</th><th>Count</th></tr></thead>
+      <tbody></tbody>
+    </table>
+  </section>
   <script src="popup.js"></script>
 </body>
 </html>

--- a/extension/popup.js
+++ b/extension/popup.js
@@ -1,2 +1,84 @@
-// Placeholder for BrowserSec popup script
-// TODO: Implement dashboard interactions and visualizations.
+function renderSiteTable(activities) {
+  const counts = {};
+  activities.forEach(({ url, actionType }) => {
+    if (!url) return;
+    let host;
+    try { host = new URL(url).hostname; } catch { return; }
+    const key = `${host}|${actionType}`;
+    counts[key] = (counts[key] || 0) + 1;
+  });
+  const rows = Object.entries(counts)
+    .map(([key, count]) => {
+      const [host, actionType] = key.split('|');
+      return { host, actionType, count };
+    })
+    .sort((a, b) => b.count - a.count)
+    .slice(0, 10);
+  const tbody = document.querySelector('#siteTable tbody');
+  tbody.innerHTML = '';
+  rows.forEach(({ host, actionType, count }) => {
+    const tr = document.createElement('tr');
+    tr.innerHTML = `<td>${host}</td><td>${actionType}</td><td>${count}</td>`;
+    tbody.appendChild(tr);
+  });
+}
+
+function renderSensitiveTable(activities) {
+  const sensitive = new Set(['SETTINGS-CHANGE', 'EMAIL-SENSITIVE-SEND']);
+  const counts = {};
+  activities
+    .filter(a => sensitive.has(a.actionType))
+    .forEach(({ actionName, url }) => {
+      let host;
+      try { host = new URL(url).hostname; } catch { host = url; }
+      const key = `${actionName}|${host}`;
+      counts[key] = (counts[key] || 0) + 1;
+    });
+  const rows = Object.entries(counts)
+    .map(([key, count]) => {
+      const [actionName, host] = key.split('|');
+      return { actionName, host, count };
+    })
+    .sort((a, b) => b.count - a.count);
+  const tbody = document.querySelector('#sensitiveTable tbody');
+  tbody.innerHTML = '';
+  rows.forEach(({ actionName, host, count }) => {
+    const tr = document.createElement('tr');
+    tr.innerHTML = `<td>${actionName}</td><td>${host}</td><td>${count}</td>`;
+    tbody.appendChild(tr);
+  });
+}
+
+function renderRareTable(activities) {
+  const counts = {};
+  activities.forEach(({ actionType }) => {
+    counts[actionType] = (counts[actionType] || 0) + 1;
+  });
+  const rows = Object.entries(counts)
+    .filter(([, count]) => count <= 2)
+    .sort((a, b) => a[1] - b[1]);
+  const tbody = document.querySelector('#rareTable tbody');
+  tbody.innerHTML = '';
+  rows.forEach(([actionType, count]) => {
+    const tr = document.createElement('tr');
+    tr.innerHTML = `<td>${actionType}</td><td>${count}</td>`;
+    tbody.appendChild(tr);
+  });
+}
+
+function renderDashboard() {
+  chrome.storage.local.get({ activities: [] }, ({ activities }) => {
+    renderSiteTable(activities);
+    renderSensitiveTable(activities);
+    renderRareTable(activities);
+  });
+}
+
+if (typeof document !== 'undefined') {
+  document.addEventListener('DOMContentLoaded', renderDashboard);
+}
+
+// Export for testing if needed
+if (typeof module !== 'undefined') {
+  module.exports = { renderSiteTable, renderSensitiveTable, renderRareTable };
+}

--- a/extension/service_worker.js
+++ b/extension/service_worker.js
@@ -87,6 +87,22 @@ async function captureAndSend(apiToken) {
             try {
               const parsed = JSON.parse(content);
               debugLog('log', 'OpenAI intent analysis', parsed);
+
+              const activity = {
+                timestamp: Date.now(),
+                url: tab.url || '',
+                appName: parsed.appName || '',
+                actionName: parsed.actionName || '',
+                miscNotes: parsed.miscNotes || '',
+                actionType: parsed.actionType || ''
+              };
+
+              chrome.storage.local.get({ activities: [] }, ({ activities }) => {
+                activities.push(activity);
+                chrome.storage.local.set({ activities }, () => {
+                  debugLog('debug', 'activity stored', activity);
+                });
+              });
             } catch (parseErr) {
               debugLog('error', 'Failed to parse AI response', parseErr, content);
             }

--- a/test/popup.test.js
+++ b/test/popup.test.js
@@ -1,0 +1,42 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { JSDOM } = require('jsdom');
+
+const { renderSiteTable, renderSensitiveTable, renderRareTable } = require('../extension/popup.js');
+
+test('renderSiteTable groups by host and action type', () => {
+  const dom = new JSDOM('<table id="siteTable"><tbody></tbody></table>');
+  global.document = dom.window.document;
+  renderSiteTable([
+    { url: 'https://example.com', actionType: 'READ' },
+    { url: 'https://example.com', actionType: 'READ' },
+    { url: 'https://example.com', actionType: 'BROWSE' },
+    { url: 'https://other.com', actionType: 'READ' }
+  ]);
+  const rows = dom.window.document.querySelectorAll('tbody tr');
+  assert.equal(rows.length, 3);
+});
+
+test('renderSensitiveTable shows only sensitive actions', () => {
+  const dom = new JSDOM('<table id="sensitiveTable"><tbody></tbody></table>');
+  global.document = dom.window.document;
+  renderSensitiveTable([
+    { actionName: 'change password', actionType: 'SETTINGS-CHANGE', url: 'https://ex.com' },
+    { actionName: 'view', actionType: 'READ', url: 'https://ex.com' }
+  ]);
+  const rows = dom.window.document.querySelectorAll('tbody tr');
+  assert.equal(rows.length, 1);
+});
+
+test('renderRareTable lists low prevalence actions', () => {
+  const dom = new JSDOM('<table id="rareTable"><tbody></tbody></table>');
+  global.document = dom.window.document;
+  renderRareTable([
+    { actionType: 'READ' },
+    { actionType: 'READ' },
+    { actionType: 'BROWSE' },
+    { actionType: 'SETTINGS-CHANGE' }
+  ]);
+  const rows = dom.window.document.querySelectorAll('tbody tr');
+  assert.equal(rows.length, 3);
+});


### PR DESCRIPTION
## Summary
- persist AI inference results to local storage for later analysis
- add popup dashboard summarizing top sites, sensitive actions, and rare actions
- test rendering helpers for dashboard tables

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a0fe2ecdd88323a7512a1d81b585f8